### PR TITLE
Upgrading to spring-formatter 0.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.spring.javaformat</groupId>
             <artifactId>spring-javaformat-maven-plugin</artifactId>
-            <version>0.0.6</version>
+            <version>0.0.12</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This commit upgrades to spring-formatter 0.12.
Note that as of 0.12 the length of the line changed to 120 characters.